### PR TITLE
repository: filename extensions

### DIFF
--- a/config/config.yml.default
+++ b/config/config.yml.default
@@ -116,3 +116,10 @@ repository:
   #git:
   #  path:        '/home/user/wiki/repository'
   #  bare:        true
+  ## set content filename extension
+  #  content_ext:  '.page'
+  ## set attribute filename prefix or extension, these can be nil or string
+  #  attribute_pre: '.'
+  #  attribute_ext: #'.attribute'
+  ## set index page name
+  #  index_page:    'Index'


### PR DESCRIPTION
this includes config options & fixes for the repo filename extensions

pages always have an extension now, this way the code got much simpler,
we don't have two different kinds of names for the pages.

In the config you can either set an attribute file prefix (I prefer a dot because it's hidden then)
or an extension. Also, I added a setting for the index page name.

Later I might improve this further to use extensions according to the mime type of the page (read from the attribute file)
