### PR TITLE
Fix bug in store handling for memcache with dalli

### DIFF
--- a/plugins/utils/store.rb
+++ b/plugins/utils/store.rb
@@ -177,7 +177,7 @@ class Store
 
       def initialize(config)
         require 'dalli'
-        @server = ::Dalli.new(config[:server], :namespace => (config[:prefix] rescue nil))
+        @server = ::Dalli::Client.new(config[:server], :namespace => (config[:prefix] rescue nil))
       end
 
       # @override


### PR DESCRIPTION
Hi

I wanted to use dalli as my memcache "handler" but it did not work. I always got a startup error like
`ERROR -- : undefined method `new' for Dalli:Module (NoMethodError)` and it did not work.

This commit fixes this.

regards
 raf
