### PR TITLE
Add after_commit hook

### DIFF
--- a/lib/olelo/page.rb
+++ b/lib/olelo/page.rb
@@ -6,6 +6,7 @@ module Olelo
     include Attributes
 
     has_around_hooks :move, :delete, :save
+    has_hooks :after_commit
 
     attributes do
       string  :title
@@ -241,6 +242,9 @@ module Olelo
 
     def after_commit(&block)
       Page.current_transaction << block
+      Page.current_transaction << Proc.new do
+        invoke_hook :after_commit
+      end
     end
 
     def self.check_path(path)


### PR DESCRIPTION
Then i can write a plugin that make push commit after save page automatically.

``` ruby
# -*- coding: utf-8 -*-
description 'exec git push after save page'

Page.hook :after_commit do
  Olelo.logger.info "push git history after save page"
  git_path = Config[:repository][:git][:path]
  response = `git --git-dir=#{git_path} --bare push origin master 2>&1`
  if $?.success?
    Olelo.logger.info "git history push success"
  else
    Olelo.logger.error "git history push failure, reason: #{response}"
  end
end
```
