### PR TITLE
Work around for issue #97

### DIFF
--- a/lib/olelo/application.rb
+++ b/lib/olelo/application.rb
@@ -75,7 +75,7 @@ module Olelo
 
     error StandardError do |error|
       Olelo.logger.error error
-      if on_error && http_accept? /html/
+      if on_error && http_accept?(/html/)
         (error.try(:messages) || [error.message]).each {|msg| flash.error!(msg) }
         halt render(on_error)
       end


### PR DESCRIPTION
I'm not sure what could have caused this syntax to go bad, but this diff allows Olelo to start up. I tried Ruby 1.9.3-p551 as well as 2.2.5, and both seem to require this patch. It may have resulted from an update to a gem of course, but I'm clutching at straws there.

By adding parenthesis around the arguments to the `http_accept?` method a potential ambiguity gets resolved.